### PR TITLE
Compatibility change for TF1 and TF2

### DIFF
--- a/cvae/cvae.py
+++ b/cvae/cvae.py
@@ -6,9 +6,9 @@ import time
 import shutil
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 try:
-    tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+    tf.logging.set_verbosity(tf.logging.ERROR)
 except:
     pass
 

--- a/cvae/lib/data_reader.py
+++ b/cvae/lib/data_reader.py
@@ -1,6 +1,6 @@
 import threading
 import random
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import numpy as np
 import joblib
 import os

--- a/cvae/lib/data_reader_array.py
+++ b/cvae/lib/data_reader_array.py
@@ -1,6 +1,6 @@
 import threading
 import random
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import numpy as np
 import joblib
 import os

--- a/cvae/lib/model_iaf.py
+++ b/cvae/lib/model_iaf.py
@@ -1,4 +1,4 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 
 def create_variable(name, shape, initializer_type=None):


### PR DESCRIPTION
Implementing this change https://github.com/maxfrenzel/CompressionVAE/issues/6#issuecomment-705720989

Note that both Tensorflow v1 and v2 have `tensorflow.compat.v1`.